### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,4 +11,4 @@ of each release, and associated metadata including licensing and the
 location of packages/source code/documentation/continuous integration.
 
 Documentation is included and is also `available online
-<http://django-project-portfolio.readthedocs.org/>`_.
+<https://django-project-portfolio.readthedocs.io/>`_.


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
